### PR TITLE
Small updates to keep code from bitrotting

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -42,3 +42,15 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
+
+  msrv:
+    name: cargo msrv
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-msrv
+      - run: cargo msrv verify

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,94 @@
+# Mostly copied from https://github.com/taiki-e/cargo-hack/blob/72a9fc95377c453a18026329577c59fa60bfa737/.github/workflows/release.yml
+name: Release
+
+permissions:
+  # TODO: once `releases: write` is supported, use it instead.
+  contents: write
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+
+defaults:
+  run:
+    # Setting shell: bash explicitly activates pipefail
+    shell: bash
+
+jobs:
+  create-release:
+    if: github.repository_owner == 'danielparks'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        run: rustup update stable --no-self-update
+      - run: cargo package
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          changelog: CHANGELOG.md
+          title: Release $version
+          branch: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-assets:
+    name: ${{ matrix.target }}
+    if: github.repository_owner == 'danielparks'
+    needs:
+      - create-release
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-musl
+          - target: aarch64-apple-darwin
+            os: macos-11
+          - target: aarch64-pc-windows-msvc
+            os: windows-2019
+          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
+          - target: x86_64-apple-darwin
+            os: macos-11
+          - target: x86_64-pc-windows-msvc
+            os: windows-2019
+          - target: x86_64-unknown-freebsd
+    runs-on: ${{ matrix.os || 'ubuntu-20.04' }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        run: rustup update stable --no-self-update
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+        if: (matrix.os == '' || startsWith(matrix.os, 'ubuntu')) && !contains(matrix.target, '-musl')
+      - uses: taiki-e/install-action@cross
+        if: contains(matrix.target, '-musl')
+      - run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >> "${GITHUB_ENV}"
+        if: endsWith(matrix.target, 'windows-msvc')
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cargo-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: directory_count
+          target: ${{ matrix.target }}
+          tar: all
+          zip: windows
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,9 +106,9 @@ checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,15 @@ authors = ["Daniel Parks <oss-directory_count@demonhorse.org>"]
 description = "Recursively count the contents of directories recursively"
 homepage = "https://github.com/danielparks/directory_count"
 repository = "https://github.com/danielparks/directory_count"
+documentation = "https://github.com/danielparks/directory_count"
 readme = "README.md"
 keywords = []
 categories = [] # https://crates.io/category_slugs
 license = "MIT OR Apache-2.0"
-edition = "2018"
-
-[badges]
+edition = "2021"
+rust-version = "1.60"
 
 [dependencies]
 anyhow = "1.0.44"
 clap = { version = "4.0.17", features = ["derive"] }
-os_str_bytes = "6.2.0"
+os_str_bytes = "6.5.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+#![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::let_underscore_untyped, clippy::map_unwrap_or)]
+
 use anyhow::Result;
 use clap::Parser;
 use os_str_bytes::OsStrBytes;
@@ -57,7 +61,7 @@ fn walk(parent: &Path) -> Result<usize> {
         }
     }
 
-    print!("{:6} ", count);
+    print!("{count:6} ");
     stdout().write_all(&parent.to_raw_bytes())?;
     println!();
 
@@ -71,9 +75,9 @@ where
     eprint!("directory-count: ");
     if let Some(path) = path {
         stderr().write_all(&path.to_raw_bytes())?;
-        eprintln!(": {}", error);
+        eprintln!(": {error}");
     } else {
-        eprintln!("{}", error);
+        eprintln!("{error}");
     }
 
     Ok(())


### PR DESCRIPTION
This generally just makes the crate more in line with my other crates. For example, `unsafe` is now forbidden, it uses edition 2021, the MSRV is explicitly set to 1.60, and most pedantic Clippy lints are enabled.