### PR TITLE
Use cargo-lints to centrally configure lints

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -38,10 +38,10 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-      - uses: actions-rs/clippy-check@v1
+      - uses: taiki-e/install-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features  --all-targets
+          tool: cargo-lints
+      - run: cargo lints clippy --all-features --all-targets
 
   deny:
     name: cargo deny

--- a/lints.toml
+++ b/lints.toml
@@ -1,0 +1,51 @@
+deny = [
+  "unsafe_code",
+]
+
+warn = [
+  "clippy::nursery",
+  "clippy::pedantic",
+
+  # Require docs
+  "missing_docs",
+  "clippy::missing_docs_in_private_items",
+
+  # Other restriction lints
+  "clippy::arithmetic_side_effects",
+  "clippy::as_underscore",
+  "clippy::assertions_on_result_states",
+  "clippy::dbg_macro",
+  "clippy::default_union_representation",
+  "clippy::empty_structs_with_brackets",
+  "clippy::filetype_is_file", # maybe?
+  "clippy::fn_to_numeric_cast_any",
+  "clippy::format_push_string", # maybe? alternative is fallible.
+  "clippy::get_unwrap",
+  "clippy::impl_trait_in_params",
+  "clippy::integer_division",
+  "clippy::lossy_float_literal",
+  "clippy::mem_forget",
+  "clippy::mixed_read_write_in_expression",
+  "clippy::multiple_inherent_impl",
+  "clippy::multiple_unsafe_ops_per_block",
+  "clippy::mutex_atomic",
+  "clippy::rc_buffer",
+  "clippy::rc_mutex",
+  "clippy::same_name_method",
+  "clippy::semicolon_inside_block",
+  "clippy::str_to_string",
+  "clippy::string_to_string",
+  "clippy::undocumented_unsafe_blocks",
+  "clippy::unnecessary_safety_doc",
+  "clippy::unnecessary_self_imports",
+  "clippy::unneeded_field_pattern",
+  "clippy::verbose_file_reads",
+]
+
+allow = [
+  # Pedantic exceptions
+  "clippy::let_underscore_untyped",
+  "clippy::manual_string_new",
+  "clippy::map_unwrap_or",
+  "clippy::module_name_repetitions",
+]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
-#![forbid(unsafe_code)]
-#![warn(clippy::pedantic)]
-#![allow(clippy::let_underscore_untyped, clippy::map_unwrap_or)]
+//! `directory-count` executable.
 
-use anyhow::Result;
+// Most lint configuration is in lints.toml, but it doesn’t support forbid.
+#![forbid(unsafe_code)]
+
+use anyhow::{anyhow, Result};
 use clap::Parser;
 use os_str_bytes::OsStrBytes;
 use std::fmt::Display;
@@ -11,6 +12,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::exit;
 
+/// Parameters for the executable.
 #[derive(Debug, clap::Parser)]
 #[clap(version, about)]
 struct Params {
@@ -25,6 +27,7 @@ fn main() {
     }
 }
 
+/// Call `walk()` on each of the parameters.
 fn cli(params: Params) -> Result<()> {
     for parent in params.directories {
         if let Err(error) = walk(&parent) {
@@ -35,30 +38,35 @@ fn cli(params: Params) -> Result<()> {
     Ok(())
 }
 
+/// Walk the directory tree under `parent` and print counts.
 fn walk(parent: &Path) -> Result<usize> {
     let mut count: usize = 1; // Count this directory.
 
     for entry in parent.read_dir()? {
-        count += match entry {
-            Ok(entry) => {
-                if entry.file_type()?.is_dir() {
-                    match walk(&entry.path()) {
-                        Ok(dir_count) => dir_count,
-                        Err(error) => {
-                            print_error(Some(&entry.path()), &error)?;
-                            1
+        count = count
+            .checked_add(match entry {
+                Ok(entry) => {
+                    if entry.file_type()?.is_dir() {
+                        match walk(&entry.path()) {
+                            Ok(dir_count) => dir_count,
+                            Err(error) => {
+                                print_error(Some(&entry.path()), &error)?;
+                                1
+                            }
                         }
+                    } else {
+                        1
                     }
-                } else {
+                }
+                Err(error) => {
+                    // FIXME should this at least show the parent path?
+                    print_error(None, &error)?;
                     1
                 }
-            }
-            Err(error) => {
-                // FIXME should this at least show the parent path?
-                print_error(None, &error)?;
-                1
-            }
-        }
+            })
+            .ok_or_else(|| {
+                anyhow!("cannot count to more than {}", usize::MAX)
+            })?;
     }
 
     print!("{count:6} ");
@@ -68,6 +76,7 @@ fn walk(parent: &Path) -> Result<usize> {
     Ok(count)
 }
 
+/// Report an error we encountered to the user.
 fn print_error<E>(path: Option<&Path>, error: &E) -> Result<()>
 where
     E: Display,


### PR DESCRIPTION
This updates the lint configuration to match my other projects. It includes a bunch more restriction lints.

To run lints:

    cargo lints clippy --all-targets --all-features

This requires [cargo-lints] to be installed.

[cargo-lints]: https://crates.io/crates/cargo-lints