### PR TITLE
Update actions and pre-commit checks to match other repos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,19 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # Security updates only:
+    open-pull-requests-limit: 0
+    groups:
+      cargo-dependencies:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-prek.yaml
+++ b/.github/workflows/dependabot-prek.yaml
@@ -1,0 +1,34 @@
+name: Dependabot `prek auto-update`
+
+on:
+  push:
+    branches:
+      - "dependabot/github_actions/**"
+
+jobs:
+  prek-auto-update:
+    # Only run on dependabot PRs
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.PUSH_TOKEN }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: prek
+      - run: prek auto-update
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if [[ -n $(git status --porcelain) ]]; then
+            git add -A
+            git commit -m $'`prek auto-update`\n\n[dependabot skip]'
+            git push
+          fi


### PR DESCRIPTION
This groups Dpendabot updates and tiggers `prek auto-update` when Dependabot
uppdates GitHub actions.
