### PR TITLE
Security: update anyhow to avoid potential unsoundness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "clap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 rust-version = "1.74.1"
 
 [dependencies]
-anyhow = "1.0.44"
+anyhow = "1.0.103"
 clap = { version = "4.5.23", features = ["derive"] }
 os_str_bytes = "6.5.0"
 


### PR DESCRIPTION
[RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190):

> Affected versions of this crate violate borrow rules, resulting in
> undefined behavior, when the user adds context to an error via
> `Error::context` and then later calls `Error::downcast_mut` on the
> returned `Error`.
